### PR TITLE
Add common workflow to be consumed by all components

### DIFF
--- a/.github/workflows/common-workflow.yaml
+++ b/.github/workflows/common-workflow.yaml
@@ -1,0 +1,14 @@
+name: Common Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  add-to-project:
+    name: Add issue to CodeFlare Sprint Board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/project-codeflare/projects/8
+          github-token: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Resolves #7 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added common-workflow to add created issues from our repos to Sprint Board

All repos will be able to run this common workflow once they are each updated to call the mentioned workflow.

**See issue for more context**

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
I think the only way of testing this would be by:
- Merging this PR
- Merging [PR to call this workflow](https://github.com/opendatahub-io/distributed-workloads/pull/148) from distributed-workloads repo
- Create an issue from distributed-workloads repo
- See if workflow is called and issue gets added to Sprint Board

If successful, we can proceed for all other repos.



<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->