### PR TITLE
Updating support functions for machine and node pools

### DIFF
--- a/support/environment.go
+++ b/support/environment.go
@@ -37,7 +37,7 @@ const (
 	InstaScaleOcmSecret = "INSTASCALE_OCM_SECRET"
 
 	// Cluster ID for OSD cluster used in tests, used for testing InstaScale
-	OsdClusterID = "CLUSTERID"
+	ClusterID = "CLUSTERID"
 
 	// Type of cluster test is run on
 	ClusterTypeEnvVar = "CLUSTER_TYPE"
@@ -77,8 +77,8 @@ func GetInstascaleOcmSecret() (string, string) {
 	return res[0], res[1]
 }
 
-func GetOsdClusterId() (string, bool) {
-	return os.LookupEnv(OsdClusterID)
+func GetClusterId() (string, bool) {
+	return os.LookupEnv(ClusterID)
 }
 
 func GetClusterType(t Test) ClusterType {

--- a/support/ocm.go
+++ b/support/ocm.go
@@ -54,7 +54,7 @@ func buildOCMConnection(secret string) (*ocmsdk.Connection, error) {
 }
 
 func MachinePools(t Test, connection *ocmsdk.Connection) func(g gomega.Gomega) []*cmv1.MachinePool {
-	osdClusterId, found := GetOsdClusterId()
+	osdClusterId, found := GetClusterId()
 	t.Expect(found).To(gomega.BeTrue(), "OSD cluster id not found, please configure environment properly")
 
 	return func(g gomega.Gomega) []*cmv1.MachinePool {
@@ -75,4 +75,24 @@ func MachinePoolId(machinePool *cmv1.MachinePool) string {
 
 func MachinePoolLabels(machinePool *cmv1.MachinePool) map[string]string {
 	return machinePool.Labels()
+}
+
+func NodePools(t Test, connection *ocmsdk.Connection) func(g gomega.Gomega) []*cmv1.NodePool {
+	clusterId, found := GetClusterId()
+	t.Expect(found).To(gomega.BeTrue(), "Cluster id not found, please configure environment properly")
+
+	return func(g gomega.Gomega) []*cmv1.NodePool {
+		nodePoolsListResponse, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterId).NodePools().List().Send()
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		return nodePoolsListResponse.Items().Slice()
+	}
+}
+
+func GetNodePools(t Test, connection *ocmsdk.Connection) []*cmv1.NodePool {
+	t.T().Helper()
+	return NodePools(t, connection)(t)
+}
+
+func NodePoolLabels(nodePool *cmv1.NodePool) map[string]string {
+	return nodePool.Labels()
 }


### PR DESCRIPTION
# Issue link
[Jira Issue](https://issues.redhat.com/browse/RHOAIENG-802)

# What changes have been made

- Updated to refer to `ClusterID` instead of `OSDClusterID`
- Added Node Pool functions.

# Verification steps
This can be verified in conjuntion with the [E2E here](https://github.com/project-codeflare/codeflare-operator/pull/311), which is currently being updated but requires these functions in order to be tested.