### PR TITLE
Verify returned error when waiting for Route to be exposed

### DIFF
--- a/support/route.go
+++ b/support/route.go
@@ -76,9 +76,12 @@ func ExposeServiceByRoute(t Test, name string, namespace string, serviceName str
 	hostname := r.Status.Ingress[0].Host
 
 	// Wait for expected HTTP code
-	t.Eventually(func() int {
-		resp, _ := http.Get("http://" + hostname)
-		return resp.StatusCode
+	t.Eventually(func() (int, error) {
+		resp, err := http.Get("http://" + hostname)
+		if err != nil {
+			return -1, err
+		}
+		return resp.StatusCode, nil
 	}, TestTimeoutLong).Should(gomega.Not(gomega.Equal(503)))
 
 	r = GetRoute(t, r.Namespace, r.Name)


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Verify that Route returns error code different from 503 AND no error is returned.
https://onsi.github.io/gomega/#category-2-making-codeeventuallycode-assertions-on-functions

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Because waiting on Route exposed failed in OpenShift CI. With current code there is no way to figure out what is the source of the failure.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->