### PR TITLE
Re-word logs in GetClusterType()

### DIFF
--- a/support/environment.go
+++ b/support/environment.go
@@ -87,7 +87,7 @@ func GetClusterId() (string, bool) {
 func GetClusterType(t Test) ClusterType {
 	clusterType, ok := os.LookupEnv(ClusterTypeEnvVar)
 	if !ok {
-		t.T().Logf("Expected environment variable %s not found, cluster type is not defined.", ClusterTypeEnvVar)
+		t.T().Logf("Environment variable %s is unset.", ClusterTypeEnvVar)
 		return UndefinedCluster
 	}
 	switch clusterType {
@@ -100,7 +100,7 @@ func GetClusterType(t Test) ClusterType {
 	case "KIND":
 		return KindCluster
 	default:
-		t.T().Logf("Expected environment variable %s contains unexpected value: '%s'", ClusterTypeEnvVar, clusterType)
+		t.T().Logf("Environment variable %s is unset or contains an incorrect value: '%s'", ClusterTypeEnvVar, clusterType)
 		return UndefinedCluster
 	}
 }


### PR DESCRIPTION

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Re-worded logs in `GetClusterType()` function. This change was made as this warning currently suggest that an env var should always need to be set, where in fact there are many scenarios where this is not required.

I.e., The [SDK e2e test](https://github.com/project-codeflare/codeflare-sdk/blob/main/tests/e2e/mnist_raycluster_sdk_test.go) can be ran without specifying the `CLUSTER_TYPE` env var if ran on OpenShift environments.

If a test does require the env var to be set, the test will fail or skip as being done i.e., on InstaScale tests: https://github.com/project-codeflare/codeflare-operator/blob/main/test/e2e/instascale_machinepool_test.go#L33-L36 


# Verification steps
PR check is sufficient.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->