### PR TITLE
Use Dnsmasq to provide DNS for KinD

### DIFF
--- a/github-actions/kind/action.yml
+++ b/github-actions/kind/action.yml
@@ -67,9 +67,22 @@ runs:
         kubectl annotate ingressclass nginx "ingressclass.kubernetes.io/is-default-class=true"
         kubectl -n ingress-nginx wait --timeout=300s --for=condition=Available deployments --all
 
-    - name: Add ${{ inputs.node-hostname }} host to machine hosts
+    - name: Setup Dnsmasq to resolve hostnames with domain name ${{ inputs.node-hostname }}
       shell: bash
-      run: echo "127.0.0.1 ${{ inputs.node-hostname }}" | sudo tee -a /etc/hosts
+      run: |
+        # Based on https://sixfeetup.com/blog/local-development-with-wildcard-dns-on-linux
+        sudo apt-get install dnsmasq
+
+        sudo sed -i -E "s/#DNS=/DNS=127.0.0.2/" /etc/systemd/resolved.conf
+        sudo sed -i -E "s/#Domains=/Domains=~${{ inputs.node-hostname }}/" /etc/systemd/resolved.conf
+        sudo systemctl restart systemd-resolved
+
+        sudo sed -i -E "s/#IGNORE_RESOLVCONF=yes/IGNORE_RESOLVCONF=yes/" /etc/default/dnsmasq
+        sudo sed -i -E "s/#listen-address=/listen-address=127.0.0.2/" /etc/dnsmasq.conf
+        sudo sed -i -E "s/#bind-interfaces/bind-interfaces/" /etc/dnsmasq.conf
+        sudo sed -i -E "s|#(address=).*|\1/${{ inputs.node-hostname }}/127.0.0.1|" /etc/dnsmasq.conf
+        sudo systemctl restart dnsmasq
+        systemctl status dnsmasq
 
     - name: Set env variables for tests to properly leverage KinD cluster
       shell: bash


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Use Dnsmasq to provide DNS wildcard support for KinD deployment used in PR checks.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Use complex hostname to send requests on KinD.
Was tested on https://github.com/project-codeflare/codeflare-operator/pull/520.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->