### PR TITLE
Enable HTTPS for KinD cluster, enable SSL passthrough

### DIFF
--- a/github-actions/kind/action.yml
+++ b/github-actions/kind/action.yml
@@ -65,6 +65,9 @@ runs:
         echo "Deploying Ingress controller into KinD cluster"
         curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/"${VERSION}"/deploy/static/provider/kind/deploy.yaml | sed "s/--publish-status-address=localhost/--report-node-internal-ip-address\\n        - --status-update-interval=10/g" | kubectl apply -f -
         kubectl annotate ingressclass nginx "ingressclass.kubernetes.io/is-default-class=true"
+        # Turn on SSL Passthrough
+        kubectl patch deploy --type json --patch '[{"op":"add","path": "/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]' ingress-nginx-controller -n ingress-nginx
+
         kubectl -n ingress-nginx wait --timeout=300s --for=condition=Available deployments --all
 
     - name: Setup Dnsmasq to resolve hostnames with domain name ${{ inputs.node-hostname }}

--- a/github-actions/kind/resources/kind.yaml
+++ b/github-actions/kind/resources/kind.yaml
@@ -23,6 +23,9 @@ nodes:
     - containerPort: 80
       hostPort: 80
       protocol: TCP
+    - containerPort: 443
+      hostPort: 443
+      protocol: TCP
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
https://issues.redhat.com/browse/RHOAIENG-7055

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Exposing HTTPS endpoint on KinD to be able to test gRPC calls.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->