### PR TITLE
Add local-queue annotation to use created local queue by default in g…

### DIFF
--- a/support/environment.go
+++ b/support/environment.go
@@ -54,6 +54,7 @@ const (
 
 	// Storage bucket credentials
 	storageDefaultEndpoint = "AWS_DEFAULT_ENDPOINT"
+	storageDefaultRegion   = "AWS_DEFAULT_REGION"
 	storageAccessKeyId     = "AWS_ACCESS_KEY_ID"
 	storageSecretKey       = "AWS_SECRET_ACCESS_KEY"
 	storageBucketName      = "AWS_STORAGE_BUCKET"
@@ -131,6 +132,11 @@ func GetMnistDatasetURL() string {
 func GetStorageBucketDefaultEndpoint() (string, bool) {
 	storage_endpoint, exists := os.LookupEnv(storageDefaultEndpoint)
 	return storage_endpoint, exists
+}
+
+func GetStorageBucketDefaultRegion() (string, bool) {
+	storage_default_region, exists := os.LookupEnv(storageDefaultRegion)
+	return storage_default_region, exists
 }
 
 func GetStorageBucketAccessKeyId() (string, bool) {

--- a/support/kueue_test.go
+++ b/support/kueue_test.go
@@ -56,8 +56,20 @@ func TestCreateKueueLocalQueue(t *testing.T) {
 
 	test.Expect(lq).To(gomega.Not(gomega.BeNil()))
 	test.Expect(lq.GenerateName).To(gomega.Equal("lq-"))
+	annotationKey := "kueue.x-k8s.io/default-queue"
+	_, exists := lq.Annotations[annotationKey]
+	test.Expect(exists).To(gomega.BeFalse(), "Annotation key %s should not exist", annotationKey)
 	test.Expect(lq.Namespace).To(gomega.Equal("ns-1"))
 	test.Expect(lq.Spec.ClusterQueue).To(gomega.Equal(kueuev1beta1.ClusterQueueReference("cq-1")))
+
+	default_lq := CreateKueueLocalQueue(test, "ns-2", "cq-2", AsDefaultQueue)
+
+	test.Expect(default_lq).To(gomega.Not(gomega.BeNil()))
+	test.Expect(default_lq.GenerateName).To(gomega.Equal("lq-"))
+	test.Expect(default_lq.Annotations["kueue.x-k8s.io/default-queue"]).To(gomega.Equal("true"))
+	test.Expect(default_lq.Namespace).To(gomega.Equal("ns-2"))
+	test.Expect(default_lq.Spec.ClusterQueue).To(gomega.Equal(kueuev1beta1.ClusterQueueReference("cq-2")))
+
 }
 
 func TestGetKueueWorkloads(t *testing.T) {


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
https://github.com/opendatahub-io/distributed-workloads/pull/198

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

- Use annotation to allow creating raycluster using default local-queue created in given namespace
- Add support for providing `AWS_DEFAULT_REGION `environment variable 

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->