### PR TITLE
Ray cluster client redesign

### DIFF
--- a/support/ray_api.go
+++ b/support/ray_api.go
@@ -27,9 +27,9 @@ func GetRayJobAPIDetails(t Test, rayClient RayClusterClient, jobID string) *RayJ
 
 func WriteRayJobAPILogs(t Test, rayClient RayClusterClient, jobID string) {
 	t.T().Helper()
-	logs, err := rayClient.GetJobLogs(jobID)
+	jobLogs, err := rayClient.GetJobLogs(jobID)
 	t.Expect(err).NotTo(gomega.HaveOccurred())
-	WriteToOutputDir(t, "ray-job-log-"+jobID, Log, []byte(logs))
+	WriteToOutputDir(t, "ray-job-log-"+jobID, Log, []byte(jobLogs.Logs))
 }
 
 func RayJobAPIDetails(t Test, rayClient RayClusterClient, jobID string) func(g gomega.Gomega) *RayJobDetailsResponse {

--- a/support/ray_cluster_client_helper.go
+++ b/support/ray_cluster_client_helper.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package support
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/transport"
+)
+
+func GetRayClusterClient(t Test, dashboardURL, bearerToken string) RayClusterClient {
+	t.T().Helper()
+
+	// Skip TLS check to work on clusters with insecure certificates too
+	// Functionality intended just for testing purpose, DO NOT USE IN PRODUCTION
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
+	}
+	client, err := NewRayClusterClient(RayClusterClientConfig{
+		Address: dashboardURL,
+		Client:  &http.Client{Transport: transport.NewBearerAuthRoundTripper(bearerToken, tr)},
+	})
+	t.Expect(err).NotTo(HaveOccurred())
+
+	return client
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Rewritten `NewRayClusterClient` function to accept only `RayClusterClientConfig` with all the needed configuration.
`RayClusterClientConfig`  allows users to pass `http.Client` with any configuration which user needs, providing configuration flexibility.
Simplified and adjusted client functions to better reflect underlying REST API.

Purpose is to make Ray client flexible enough to allow its usage outside of RHOAI, potentially donating it to Ray community.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Verified by using the new implementation in ODH/DW repo to run integration tests.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->