### PR TITLE
Cleanup of codeflare-common defaults and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
-# CODEFLARE_SDK_VERSION defines the default version of the CodeFlare SDK
-CODEFLARE_SDK_VERSION ?= 0.9.0
-
 # RAY_VERSION defines the default version of Ray (used for testing)
 RAY_VERSION ?= 2.35.0
 
 # RAY_IMAGE defines the default container image for Ray (used for testing)
-RAY_IMAGE ?= rayproject/ray:$(RAY_VERSION)
+RAY_IMAGE ?= quay.io/modh/ray:2.35.0-py39-cu121
 
 ##@ Development
 
@@ -21,7 +18,6 @@ defaults:
 	@echo "// ***********************" >> $(DEFAULTS_TEST_FILE)
 	@echo "" >> $(DEFAULTS_TEST_FILE)
 	@echo "const (" >> $(DEFAULTS_TEST_FILE)
-	@echo "  CodeFlareSDKVersion = \"$(CODEFLARE_SDK_VERSION)\"" >> $(DEFAULTS_TEST_FILE)
 	@echo "  RayVersion = \"$(RAY_VERSION)\"" >> $(DEFAULTS_TEST_FILE)
 	@echo "  RayImage = \"$(RAY_IMAGE)\"" >> $(DEFAULTS_TEST_FILE)
 	@echo "" >> $(DEFAULTS_TEST_FILE)

--- a/support/defaults.go
+++ b/support/defaults.go
@@ -5,7 +5,6 @@ package support
 // ***********************
 
 const (
-	CodeFlareSDKVersion = "v0.20.2"
-	RayVersion          = "2.35.0"
-	RayImage            = "quay.io/modh/ray:2.35.0-py39-cu121"
+	RayVersion = "2.35.0"
+	RayImage   = "quay.io/modh/ray:2.35.0-py39-cu121"
 )

--- a/support/environment.go
+++ b/support/environment.go
@@ -25,7 +25,6 @@ const (
 	// The environment variables hereafter can be used to change the components
 	// used for testing.
 
-	CodeFlareTestSdkVersion   = "CODEFLARE_TEST_SDK_VERSION"
 	CodeFlareTestRayVersion   = "CODEFLARE_TEST_RAY_VERSION"
 	CodeFlareTestRayImage     = "CODEFLARE_TEST_RAY_IMAGE"
 	CodeFlareTestPyTorchImage = "CODEFLARE_TEST_PYTORCH_IMAGE"
@@ -70,10 +69,6 @@ const (
 	KindCluster       ClusterType = "KIND"
 	UndefinedCluster  ClusterType = "UNDEFINED"
 )
-
-func GetCodeFlareSDKVersion() string {
-	return lookupEnvOrDefault(CodeFlareTestSdkVersion, CodeFlareSDKVersion)
-}
 
 func GetRayVersion() string {
 	return lookupEnvOrDefault(CodeFlareTestRayVersion, RayVersion)

--- a/support/environment_test.go
+++ b/support/environment_test.go
@@ -8,21 +8,6 @@ import (
 	"github.com/onsi/gomega"
 )
 
-func TestGetCodeFlareSDKVersion(t *testing.T) {
-
-	g := gomega.NewGomegaWithT(t)
-	// Set the environment variable.
-	os.Setenv(CodeFlareTestSdkVersion, "1.2.3")
-
-	// Get the version.
-	version := GetCodeFlareSDKVersion()
-
-	// Assert that the version is correct.
-
-	g.Expect(version).To(gomega.Equal("1.2.3"), "Expected version 1.2.3, but got %s", version)
-
-}
-
 func TestGetRayVersion(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)


### PR DESCRIPTION
Removing CodeFlare SDK version as CodeFlare SDK doesn't use Go lang tests any more. 
Adjusted Makefile to align with current content of defaults.go

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Cleanup of default values and Makefile.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
N/A, there should be no functionality change.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->