### PR TITLE
Make one common env variable for all ray images

### DIFF
--- a/support/environment.go
+++ b/support/environment.go
@@ -25,12 +25,9 @@ const (
 	// The environment variables hereafter can be used to change the components
 	// used for testing.
 
-	CodeFlareTestRayVersion        = "CODEFLARE_TEST_RAY_VERSION"
-	CodeFlareTestRayImage          = "CODEFLARE_TEST_RAY_IMAGE"
-	CodeFlareTestRayROCmImage      = "CODEFLARE_TEST_RAY_ROCM_IMAGE"
-	CodeFlareTestRayTorchCudaImage = "CODEFLARE_TEST_RAY_TORCH_CUDA_IMAGE"
-	CodeFlareTestRayTorchROCmImage = "CODEFLARE_TEST_RAY_TORCH_ROCM_IMAGE"
-	CodeFlareTestPyTorchImage      = "CODEFLARE_TEST_PYTORCH_IMAGE"
+	CodeFlareTestRayVersion   = "CODEFLARE_TEST_RAY_VERSION"
+	CodeFlareTestRayImage     = "CODEFLARE_TEST_RAY_IMAGE"
+	CodeFlareTestPyTorchImage = "CODEFLARE_TEST_PYTORCH_IMAGE"
 
 	// The testing output directory, to write output files into.
 	CodeFlareTestOutputDir = "CODEFLARE_TEST_OUTPUT_DIR"
@@ -82,15 +79,15 @@ func GetRayImage() string {
 }
 
 func GetRayROCmImage() string {
-	return lookupEnvOrDefault(CodeFlareTestRayROCmImage, RayROCmImage)
+	return lookupEnvOrDefault(CodeFlareTestRayImage, RayROCmImage)
 }
 
 func GetRayTorchCudaImage() string {
-	return lookupEnvOrDefault(CodeFlareTestRayTorchCudaImage, RayTorchCudaImage)
+	return lookupEnvOrDefault(CodeFlareTestRayImage, RayTorchCudaImage)
 }
 
 func GetRayTorchROCmImage() string {
-	return lookupEnvOrDefault(CodeFlareTestRayTorchROCmImage, RayTorchROCmImage)
+	return lookupEnvOrDefault(CodeFlareTestRayImage, RayTorchROCmImage)
 }
 
 func GetPyTorchImage() string {


### PR DESCRIPTION
# What changes have been made
Make one common env variable for all ray images as it helps to pass the any custom ray image with one environment variable instead of specifying a separate environment variables for different ray images. 

Also with increase in number of accelerators in future, it will keep increasing environment variables.



