### PR TITLE
Add option to specify test namespace name using TEST_NAMESPACE_NAME e…

### DIFF
--- a/support/environment.go
+++ b/support/environment.go
@@ -58,6 +58,9 @@ const (
 	storageSecretKey       = "AWS_SECRET_ACCESS_KEY"
 	storageBucketName      = "AWS_STORAGE_BUCKET"
 	storageBucketMnistDir  = "AWS_STORAGE_BUCKET_MNIST_DIR"
+
+	// Name of existing namespace to be used for test
+	testNamespaceNameEnvVar = "TEST_NAMESPACE_NAME"
 )
 
 type ClusterType string
@@ -172,6 +175,10 @@ func GetPipIndexURL() string {
 
 func GetPipTrustedHost() string {
 	return lookupEnvOrDefault(pipTrustedHost, "")
+}
+
+func GetTestNamespaceName() (string, bool) {
+	return os.LookupEnv(testNamespaceNameEnvVar)
 }
 
 func lookupEnvOrDefault(key, value string) string {

--- a/support/test_test.go
+++ b/support/test_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package support
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateOrGetTestNamespaceCreatingNamespace(t *testing.T) {
+	test := NewTest(t)
+
+	namespace := test.CreateOrGetTestNamespace()
+
+	test.Expect(namespace).NotTo(BeNil())
+	test.Expect(namespace.GenerateName).To(Equal("test-ns-"))
+}
+
+func TestCreateOrGetTestNamespaceGettingExistingNamespace(t *testing.T) {
+	test := NewTest(t)
+
+	CreateTestNamespaceWithName(test, "test-namespace")
+	os.Setenv(testNamespaceNameEnvVar, "test-namespace")
+	defer os.Unsetenv(testNamespaceNameEnvVar)
+
+	namespace := test.CreateOrGetTestNamespace()
+
+	test.Expect(namespace).NotTo(BeNil())
+	test.Expect(namespace.Name).To(Equal("test-namespace"))
+}
+
+func TestCreateOrGetTestNamespaceGettingNonExistingNamespace(t *testing.T) {
+	test := NewTest(t)
+
+	os.Setenv(testNamespaceNameEnvVar, "non-existing-namespace")
+	defer os.Unsetenv(testNamespaceNameEnvVar)
+
+	namespace := test.CreateOrGetTestNamespace()
+
+	test.Expect(namespace).NotTo(BeNil())
+	test.Expect(namespace.Name).To(Equal("non-existing-namespace"))
+}


### PR DESCRIPTION
…nv var

# Issue link
N/A

# What changes have been made
Add possibility to run tests against existing namespace defined by `TEST_NAMESPACE_NAME` env var. In this case the namespace is not deleted in the end of the test and no logs are stored (all is left as user responsibility). Created cluster resources are still deleted.

# Verification steps
Verified by unit tests.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->