### PR TITLE
no-jira: fix flaky KinD setup by refreshing apt index before installing dnsmasq

### DIFF
--- a/github-actions/kind/action.yml
+++ b/github-actions/kind/action.yml
@@ -94,6 +94,7 @@ runs:
       shell: bash
       run: |
         # Based on https://sixfeetup.com/blog/local-development-with-wildcard-dns-on-linux
+        sudo apt-get update
         sudo apt-get -y install dnsmasq
 
         sudo sed -i -E "s/#DNS=/DNS=127.0.0.2/" /etc/systemd/resolved.conf


### PR DESCRIPTION
## Summary

- Adds `sudo apt-get update` before `sudo apt-get -y install dnsmasq` in the KinD composite action
- Fixes intermittent 404s when the GitHub Actions runner's apt cache is stale and the pinned dnsmasq package version has been superseded in the Ubuntu mirror

## Context

This has been causing flaky e2e failures across all repos that consume this action (e.g. codeflare-sdk). Example failure: https://github.com/project-codeflare/codeflare-sdk/actions/runs/25808286483/job/75817157044

```
Err:1 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 dnsmasq-base amd64 2.90-2ubuntu0.1
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch ...dnsmasq-base_2.90-2ubuntu0.1_amd64.deb  404  Not Found
```